### PR TITLE
Replace tool-panel to atom-panel

### DIFF
--- a/keymaps/ergonomic-cursor.cson
+++ b/keymaps/ergonomic-cursor.cson
@@ -48,6 +48,6 @@
   # text editing
   'cmd-space': 'ergonomic-cursor:activate-selection'
 
-'.select-list, .tree-view, .preview-pane, .tool-panel':
+'.select-list, .tree-view, .preview-pane, .atom-panel':
   'cmd-k': 'core:move-down'
   'cmd-i': 'core:move-up'


### PR DESCRIPTION
In keymaps/ergonomic-cursor.cson: Use the selector atom-panel instead of the tool-panel class.

---

see: #2 
